### PR TITLE
Fix input arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ probably using the configure-aws-credentials action.
 **Required** The AWS region to use. Default `us-east-2`.
 
 ## `CLUSTER`
-**Required** The name of your EKS cluster.
+**Required** The arguments to pass to kubectl.
+
+## Inputs
+## `kubectl-command`
+**Required** The file or files against which you want to run kubectl apply.
 
 ## Example usage
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,12 @@
 # action.yml
 name: 'kubectl-eks-apply'
 description: 'Apply all k8s manifest files on an EKS cluster'
+inputs:
+  kubectl-command:
+    description: "The arguments to pass to kubectl."
+    required: true
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - ${{ inputs.files-to-apply }}
+    - ${{ inputs.kubectl-command }}


### PR DESCRIPTION
- previous inputs were removed, but the args referencing them were not. Changed to an input called kubectl-command